### PR TITLE
Update MediatR and Hangfire packages to latest version

### DIFF
--- a/src/CommandScheduler/CommandScheduler.csproj
+++ b/src/CommandScheduler/CommandScheduler.csproj
@@ -15,13 +15,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.7.31" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.7.31" />
-    <PackageReference Include="Hangfire.Core" Version="1.7.31" />
-    <PackageReference Include="Hangfire.SqlServer" Version="1.7.31" />
-    <PackageReference Include="MediatR" Version="10.0.1" />
-    <PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="10.0.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="Hangfire" Version="1.8.15" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.15" />
+    <PackageReference Include="Hangfire.Core" Version="1.8.15" />
+    <PackageReference Include="Hangfire.SqlServer" Version="1.8.15" />
+    <PackageReference Include="MediatR" Version="12.4.1" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.8.6" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/CommandScheduler/CommandsSchedulerServiceCollectionExtensions.cs
+++ b/src/CommandScheduler/CommandsSchedulerServiceCollectionExtensions.cs
@@ -5,17 +5,17 @@ using MediatR;
 using Microsoft.Extensions.DependencyInjection;
 using System;
 using System.Data.SqlClient;
+using System.Reflection;
 
 namespace CommandScheduler
 {
     public static class CommandsSchedulerServiceCollectionExtensions
     {
-        public static IServiceCollection AddCommandsScheduler(this IServiceCollection services, string hangfireConnection, params Type[] handlerAssemblyMarkerTypes)
+        public static IServiceCollection AddCommandsScheduler(this IServiceCollection services, string hangfireConnection, params Assembly[] handlerAssemblies)
         {
             services.AddScoped<CommandsExecutor>();
             services.AddScoped<AsyncCommand>();
-
-
+            
             // Add Hangfire services.
             services.AddHangfire(configuration => configuration
                 .SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
@@ -33,7 +33,7 @@ namespace CommandScheduler
             // Add the processing server as IHostedService
             services.AddHangfireServer();
 
-            services.AddMediatR(handlerAssemblyMarkerTypes);
+            services.AddMediatR(cfg => cfg.RegisterServicesFromAssemblies(handlerAssemblies));
 
             return services;
         }


### PR DESCRIPTION
This includes a breaking change to the AddCommandsScheduler IServiceCollection. This is due to the change with how MediatR does configuration